### PR TITLE
Fix build without fixx11h.h

### DIFF
--- a/src/outputgraphicsitem.cpp
+++ b/src/outputgraphicsitem.cpp
@@ -16,15 +16,15 @@
  *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-#include "outputgraphicsitem.h"
-#include "outputconfig.h"
-#include "randr.h"
-
 #include <QtGui/QPen>
 #include <QtGui/QBrush>
 #include <QtGui/QFont>
 #include <QtGui/QGraphicsScene>
 #include <QtGui/QApplication>
+
+#include "outputconfig.h"
+#include "outputgraphicsitem.h"
+#include "randr.h"
 
 OutputGraphicsItem::OutputGraphicsItem(OutputConfig *config)
     : m_config( config )

--- a/src/randr.cpp
+++ b/src/randr.cpp
@@ -19,8 +19,8 @@
  */
 
 #include <QtGui/QIcon>
-#include "randr.h"
 #include "qtimerconfirmdialog.h"
+#include "randr.h"
 
 bool RandR::has_1_2 = true;
 bool RandR::has_1_3 = true;

--- a/src/randr.h
+++ b/src/randr.h
@@ -27,18 +27,7 @@
 #include <QtGui/QPixmap>
 #include <config-randr.h>
 
-extern "C"
-{
-#include <X11/Xlib.h>
-#define INT8 _X11INT8
-#define INT32 _X11INT32
-#include <X11/Xproto.h>
-#undef INT8
-#undef INT32
 #include <X11/extensions/Xrandr.h>
-}
-
-#include <fixx11h.h>
 
 #ifdef HAS_RANDR_1_2
 class RandRScreen;

--- a/src/randrdisplay.h
+++ b/src/randrdisplay.h
@@ -24,7 +24,6 @@
 #include <QtGui/QWidget>
 #include <QtCore/QSettings>
 #include <X11/Xlib.h>
-#include <fixx11h.h>
 
 #include "randr.h"
 

--- a/src/randrscreen.cpp
+++ b/src/randrscreen.cpp
@@ -17,13 +17,13 @@
  *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+#include <QtCore/QSettings>
+#include <QtGui/QAction>
+
 #include "randrscreen.h"
 #include "randrcrtc.h"
 #include "randroutput.h"
 #include "randrmode.h"
-
-#include <QtCore/QSettings>
-#include <QtGui/QAction>
 #include <X11/extensions/Xrandr.h>
 
 RandRScreen::RandRScreen(int screenIndex)


### PR DESCRIPTION
This fixes issue #1 by rearrange headers to build in such a way that fixx11h.h isn't needed (the X11 headers are the last ones included).
